### PR TITLE
Fix #25 issue with extra white space when custom header/footer are off.

### DIFF
--- a/lib/markdown-themeable-pdf.js
+++ b/lib/markdown-themeable-pdf.js
@@ -377,7 +377,10 @@ module.exports = markdownThemeablePdf = {
                         typeof obj.height === 'undefined' ||
                         typeof obj.contents === 'undefined') {
 
-                        return {html: ''};
+                        return {
+                            height: '0cm',
+                            html: ''
+                        };
                     }
 
                     var $ = cheerio.load(obj.contents);
@@ -412,7 +415,10 @@ module.exports = markdownThemeablePdf = {
                         typeof obj.height === 'undefined' ||
                         typeof obj.contents === 'undefined') {
 
-                        return {html: ''};
+                        return {
+                            height: '0cm',
+                            html: ''
+                        };
                     }
 
                     var $ = cheerio.load(obj.contents);

--- a/lib/markdown-themeable-pdf.js
+++ b/lib/markdown-themeable-pdf.js
@@ -364,7 +364,10 @@ module.exports = markdownThemeablePdf = {
 
             var customHeader = (function () {
                 if (!atom.config.get('markdown-themeable-pdf.enableCustomHeader') || exportType == 'html')
-                    return {html: ''};
+                    return {
+                        height: '0cm',
+                        html: ''
+                    };
 
                 var setting = markdownThemeablePdf.getConfigFilePath(atom.config.get('markdown-themeable-pdf.customHeaderPath'), filePath);
                 try {
@@ -396,7 +399,10 @@ module.exports = markdownThemeablePdf = {
             })();
             var customFooter = (function () {
                 if (!atom.config.get('markdown-themeable-pdf.enableCustomFooter') || exportType == 'html')
-                    return {html: ''};
+                    return {
+                        height: '0cm',
+                        html: ''
+                    };
 
                 var setting = markdownThemeablePdf.getConfigFilePath(atom.config.get('markdown-themeable-pdf.customFooterPath'), filePath);
                 try {


### PR DESCRIPTION
A height of 0cm should be specify so no extra space is added when exporting the pdf file.
