### PR TITLE
Allowing user to provide exact width/height dimensions

### DIFF
--- a/lib/markdown-themeable-pdf.js
+++ b/lib/markdown-themeable-pdf.js
@@ -19,6 +19,20 @@ module.exports = markdownThemeablePdf = {
             description: 'Available only for export as pdf, jpg, png.',
             order: 20
         },
+        width: {
+            title: 'Papersize Width',
+            type: 'string',
+            default: '',
+            description: 'E.g. 10.5in, overrides Papersize Format if set. Allowed units: mm, cm, in, px',
+            order: 25
+        },
+        height: {
+            title: 'Papersize Height',
+            type: 'string',
+            default: '',
+            description: 'E.g. 8in, overrides Papersize Format if set. Allowed units: mm, cm, in, px',
+            order: 26
+        },
         // @todo add hljs class to pre > code blocks with no language definition
         // codeHighlightingAuto: {
         //     title: 'Try to highlight code blocks with no language definition',
@@ -461,8 +475,15 @@ module.exports = markdownThemeablePdf = {
                 });
             } else {
                 var htmlToPdf = require('html-pdf');
+
+                var width = atom.config.get('markdown-themeable-pdf.width');
+                var height = atom.config.get('markdown-themeable-pdf.height');
+                var absolute = width && height;
+
                 htmlToPdf.create(dom, {
-                    format: atom.config.get('markdown-themeable-pdf.format'),
+                    format: absolute ? undefined : atom.config.get('markdown-themeable-pdf.format'),
+                    width: absolute ? width : undefined,
+                    height: absolute ? height : undefined,
                     orientation: atom.config.get('markdown-themeable-pdf.orientation'),
                     border: atom.config.get('markdown-themeable-pdf.pageBorder'),
                     type: jobInfo.exportType,


### PR DESCRIPTION
- I needed a way to produce a 6in x 9in trade book sized PDF
- Units were copied from [node-html-pdf options](https://github.com/marcbachmann/node-html-pdf/blob/3bf4c6823f6750aad0e859f5efd9f31b59e50fd9/README.md#options)
- If provided will override the Papersize dropdown
