### PR TITLE
In file params

### DIFF
--- a/lib/markdown-themeable-pdf.js
+++ b/lib/markdown-themeable-pdf.js
@@ -381,6 +381,17 @@ module.exports = markdownThemeablePdf = {
                 cssStyles += 'pre { white-space: pre-wrap !important; word-break: break-word !important; overflow: hidden !important;}';
             }
 
+            try {
+                // looks for any MPT definition made in the file comments and then try ro parse it as Json
+                var matchRe = markdown.match(/<!--\s*MTP\s*=\s*([\s\S]*?)\s*-->/);
+                if (matchRe.length > 1) {
+                    jobInfo.fileParams = JSON.parse(matchRe[1]);
+                }
+            }
+            catch (err) {
+                // due to file_parmas being an experimental feature, errors are just ignored
+            }
+
             var customHeader = (function () {
                 if (!atom.config.get('markdown-themeable-pdf.enableCustomHeader') || jobInfo.exportType == 'html')
                     return {
@@ -496,7 +507,37 @@ module.exports = markdownThemeablePdf = {
                         throw err;
                     }
                     try {
-                        var dest = fs.createWriteStream(jobInfo.destFile);
+
+                        var outputDir = jobInfo.destFile;
+                        if (jobInfo.fileParams && jobInfo.fileParams.outputDir){
+                            if (jobInfo.fileParams.outputDir.startsWith("/")) {
+                                outputDir = jobInfo.fileParams.outputDir;
+                            }
+                            else {
+                                outputDir = path.join(jobInfo.fileInfo.dir, jobInfo.fileParams.outputDir);
+                            }
+                        }
+
+                        // Creates the outputDir if it doesn't exist
+                        function directoryExists(path) {
+                            try {
+                                return fs.statSync(path).isDirectory();
+                            }
+                            catch (err) {
+                                return false;
+                            }
+                        }
+                        (function ensureDirectoryExistence(filePath) {
+                            var dirname = path.dirname(filePath);
+                            if (directoryExists(dirname)) {
+                                return true;
+                            }
+                            ensureDirectoryExistence(dirname);
+                            fs.mkdirSync(dirname);
+                        })(outputDir);
+
+                        var dest = fs.createWriteStream(outputDir);
+
                         dest.on('error', function (err) {
                             if (err) {
                                 atom.notifications.addError('Could not write to ' + jobInfo.destFileBase + ': ' + err.message);
@@ -504,13 +545,18 @@ module.exports = markdownThemeablePdf = {
                             }
                         });
                         dest.on('finish', function () {
-                            atom.notifications.addSuccess('File ' + jobInfo.destFileBase + ' was created in the same directory');
+                            if (jobInfo.destFile == outputDir) {
+                                atom.notifications.addSuccess('File ' + jobInfo.destFileBase + ' was created in the same directory');
+                            }
+                            else {
+                                atom.notifications.addSuccess('File ' + jobInfo.destFileBase + ' was created in '+outputDir);
+                            }
                             if (atom.config.get('markdown-themeable-pdf.openPdfInAtomWorkspace')) {
                                 setTimeout(function () {
                                     if (jobInfo.exportType == 'pdf' && !atom.packages.isPackageLoaded("pdf-view")) {
                                         atom.notifications.addWarning('Could not open ' + jobInfo.destFileBase + ' file for preview. Please install/activate "pdf-view" package.');
                                     } else {
-                                        atom.workspace.open(jobInfo.destFile, {searchAllPanes: true});
+                                        atom.workspace.open(outputDir, {searchAllPanes: true});
                                     }
                                 }, 666);
                             }


### PR DESCRIPTION
Grabs a definition of MTP (as Json) in the file comments (if there's one) and save it as fileParams in the jobInfo variable.

Also if there's an "outputDir" definition on MTP, uses that as the new path for the generated pdf.
(this last option was added as a quick solution for [issue #44](https://github.com/cakebake/markdown-themeable-pdf/issues/44))

For example:

```
<!--
  MTP = {
    "author": "José Castro",
    "outputDir": "pdf/out.pdf"
  }
-->
```

will expose author and outputDir via info.fileParams to use on the custom header or footer and the generated pdf will be saved as out.pdf in the pdf folder.
