### PR TITLE
use atom.getConfigDirPath() instead of atom.config.configDirPath

### DIFF
--- a/lib/markdown-themeable-pdf.js
+++ b/lib/markdown-themeable-pdf.js
@@ -209,7 +209,7 @@ module.exports = markdownThemeablePdf = {
         );
 
         var ncp = require('ncp').ncp;
-        var customTemplatesPath = path.resolve(atom.config.configDirPath, 'markdown-themeable-pdf');
+        var customTemplatesPath = path.resolve(atom.getConfigDirPath(), 'markdown-themeable-pdf');
         var customTemplatesSource = path.resolve(__dirname, '../markdown-themeable-pdf');
         ncp(customTemplatesSource, customTemplatesPath, {clobber: false}, function (err) {
             if (!err)


### PR DESCRIPTION
Error message from issue #74 is thrown every time opening Atom after updating Atom to 1.25. 

This fixes #74.